### PR TITLE
Adds PortfolioManager::REST::Customer module

### DIFF
--- a/lib/portfolio_manager/rest/api.rb
+++ b/lib/portfolio_manager/rest/api.rb
@@ -3,6 +3,7 @@ require 'portfolio_manager/rest/building'
 require 'portfolio_manager/rest/data_exchange_settings'
 require 'portfolio_manager/rest/meter'
 require 'portfolio_manager/rest/property'
+require 'portfolio_manager/rest/customer'
 
 module PortfolioManager
   module REST
@@ -15,6 +16,7 @@ module PortfolioManager
       include PortfolioManager::REST::DataExchangeSettings
       include PortfolioManager::REST::Meter
       include PortfolioManager::REST::Property
+      include PortfolioManager::REST::Customer
     end
   end
 end

--- a/lib/portfolio_manager/rest/customer.rb
+++ b/lib/portfolio_manager/rest/customer.rb
@@ -1,0 +1,28 @@
+require 'portfolio_manager/rest/utils'
+
+module PortfolioManager
+  module REST
+    ##
+    # Customer services
+    # @see https://portfoliomanager.energystar.gov/webservices/home/api/account
+    module Customer
+      include PortfolioManager::REST::Utils
+
+      ##
+      # Returns a list of customers that you are connected to.
+      #
+      # @see https://portfoliomanager.energystar.gov/webservices/home/api/account/customerList/get
+      def customer_list
+        perform_get_request("/customer/list")
+      end
+
+      ##
+      # Returns general account information for a specific customer that you are connected to.
+      #
+      # https://portfoliomanager.energystar.gov/webservices/home/api/account/customer/get
+      def customer(customer_id)
+        perform_get_request("/cutomer/#{customer_id}")
+      end
+    end
+  end
+end

--- a/spec/fixtures/customer_list.xml
+++ b/spec/fixtures/customer_list.xml
@@ -1,0 +1,9 @@
+<response status="Ok">
+  <links>
+    <link id="143" hint="QWERTY Company" httpMethod="GET" link="/customer/143" linkDescription="This is the GET url for this Customer."/>
+    <link id="5432" hint="Galaxy Corp" httpMethod="GET" link="/customer/5432" linkDescription="This is the GET url for this Customer."/>
+    <link id="5553" hint="Thrift Bank" httpMethod="GET" link="/customer/5553" linkDescription="This is the GET url for this Customer."/>
+    <link id="1454" httpMethod="GET" link="/customer/1454" linkDescription="This is the GET url for this Customer."/>
+    <link id="86785" hint="Sample Company" httpMethod="GET" link="/customer/86785" linkDescription="This is the GET url for this Customer."/>
+  </links>
+</response>

--- a/spec/lib/portfolio_manager/rest/customer_spec.rb
+++ b/spec/lib/portfolio_manager/rest/customer_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe PortfolioManager::REST::Customer do
+  let(:client) { test_client }
+  describe '#customer_list' do
+    before do
+      stub_get("/customer/list")
+        .to_return(body: fixture('customer_list.xml'))
+    end
+    it 'returns a list of customers' do
+      client.customer_list['response']['links']['link'].each do |link|
+        expect(link).to include '@id', '@link'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using this gem to integrate with Portfolio Manager, but it is missing some functionality that would be useful to us.

For starters, we need to be able to pull a list of accounts that we are a web service provider for (so that we may access their account ids): /customers/list

https://portfoliomanager.energystar.gov/webservices/home/api/account/customerList/get

This pull request adds that functionality.