### PR TITLE
Adds Connection Services / Post Requests / Fixes get customer

### DIFF
--- a/lib/portfolio_manager/rest/api.rb
+++ b/lib/portfolio_manager/rest/api.rb
@@ -4,6 +4,7 @@ require 'portfolio_manager/rest/data_exchange_settings'
 require 'portfolio_manager/rest/meter'
 require 'portfolio_manager/rest/property'
 require 'portfolio_manager/rest/customer'
+require 'portfolio_manager/rest/connection'
 
 module PortfolioManager
   module REST
@@ -17,6 +18,7 @@ module PortfolioManager
       include PortfolioManager::REST::Meter
       include PortfolioManager::REST::Property
       include PortfolioManager::REST::Customer
+      include PortfolioManager::REST::Connection
     end
   end
 end

--- a/lib/portfolio_manager/rest/connection.rb
+++ b/lib/portfolio_manager/rest/connection.rb
@@ -3,8 +3,8 @@ require 'portfolio_manager/rest/utils'
 module PortfolioManager
   module REST
     ##
-    # Customer services
-    # @see https://portfoliomanager.energystar.gov/webservices/home/api/account
+    # Connection services
+    # @see https://portfoliomanager.energystar.gov/webservices/home/api/connection
     module Connection
       include PortfolioManager::REST::Utils
 
@@ -40,7 +40,7 @@ module PortfolioManager
             xml.note note
           }
         end
-        builder.doc.root.to_s
+        builder.doc.root.to_xml
       end
     end
   end

--- a/lib/portfolio_manager/rest/connection.rb
+++ b/lib/portfolio_manager/rest/connection.rb
@@ -1,0 +1,47 @@
+require 'portfolio_manager/rest/utils'
+
+module PortfolioManager
+  module REST
+    ##
+    # Customer services
+    # @see https://portfoliomanager.energystar.gov/webservices/home/api/account
+    module Connection
+      include PortfolioManager::REST::Utils
+
+      ##
+      # Returns a list of customer connection requests that are pending.
+      #
+      # @see https://portfoliomanager.energystar.gov/webservices/home/api/connection/pendingAccountList/get
+      def pending_list
+        perform_get_request("/connect/account/pending/list")
+      end
+
+      ##
+      # Accepts/rejects a pending connection request from a specific customer.
+      #
+      # https://portfoliomanager.energystar.gov/webservices/home/api/connection/connect/post
+      def connection(customer_id, accept = true)
+        perform_post_request(
+            "/connect/account/#{customer_id}",
+            body: request_body(accept)
+          )
+      end
+
+      private
+
+      def request_body(accept)
+        reject_note = 'Unfortunately we cannot provide services for you at this time.'
+        accept_note = 'Your connection request has been verified and accepted.'
+        action = accept ? 'Accept' : 'Reject'
+        note = accept ? accept_note : reject_note
+        builder = Nokogiri::XML::Builder.new do |xml|
+          xml.sharingResponse {
+            xml.action action
+            xml.note note
+          }
+        end
+        builder.doc.root.to_s
+      end
+    end
+  end
+end

--- a/lib/portfolio_manager/rest/customer.rb
+++ b/lib/portfolio_manager/rest/customer.rb
@@ -21,7 +21,7 @@ module PortfolioManager
       #
       # https://portfoliomanager.energystar.gov/webservices/home/api/account/customer/get
       def customer(customer_id)
-        perform_get_request("/cutomer/#{customer_id}")
+        perform_get_request("/customer/#{customer_id}")
       end
     end
   end

--- a/lib/portfolio_manager/rest/request.rb
+++ b/lib/portfolio_manager/rest/request.rb
@@ -11,7 +11,7 @@ module PortfolioManager
       TEST_PATH = '/wstest'
       CONTENT_TYPE = 'application/xml'
 
-      attr_reader :client, :path, :request_method, :parser, :request_body, :full_path
+      attr_reader :client, :path, :request_method, :parser
       attr_accessor :options
       ##
       # @param [PortfolioManager::Client] client
@@ -66,10 +66,6 @@ module PortfolioManager
         options[:query].each do |key, value|
           @conn.query[key] = value
         end unless options[:query].nil?
-      end
-
-      def set_body
-        @request_body = options[:body]
       end
 
       def set_basic_authentication

--- a/lib/portfolio_manager/rest/utils.rb
+++ b/lib/portfolio_manager/rest/utils.rb
@@ -15,6 +15,13 @@ module PortfolioManager
       end
 
       ##
+      # @param [String] path
+      # @param [Hash] options
+      def perform_post_request(path, options = {})
+        perform_request(:post, path, options)
+      end
+
+      ##
       # @param [Symbol, String] request_method
       # @param [String] path
       # @param [Hash] options

--- a/spec/fixtures/connection.xml
+++ b/spec/fixtures/connection.xml
@@ -1,0 +1,1 @@
+<response status="Ok"/>

--- a/spec/fixtures/connection_accept.xml
+++ b/spec/fixtures/connection_accept.xml
@@ -1,0 +1,4 @@
+<sharingResponse>
+  <action>Accept</action>
+  <note>Your connection request has been verified and accepted.</note>
+</sharingResponse>

--- a/spec/fixtures/connection_reject.xml
+++ b/spec/fixtures/connection_reject.xml
@@ -1,0 +1,4 @@
+<sharingResponse>
+  <action>Reject</action>
+  <note>Unfortunately we cannot provide services for you at this time.</note>
+</sharingResponse>

--- a/spec/fixtures/customer.xml
+++ b/spec/fixtures/customer.xml
@@ -1,0 +1,13 @@
+<customer>
+    <username>acme_customer</username>
+    <includeTestPropertiesInGraphics>true</includeTestPropertiesInGraphics>
+    <accountInfo>
+        <firstName>John</firstName>
+        <lastName>Doe</lastName>
+        <address address1="123 Main St" city="Arlington"
+                 state="VA" postalCode="22201" country="US"/>
+        <email>john_doe@acme.com</email>
+        <organization>ACME Corporation</organization>
+        <jobTitle>Building Administrator Data Exchange User</jobTitle>
+    </accountInfo>
+</customer>

--- a/spec/fixtures/pending_list.xml
+++ b/spec/fixtures/pending_list.xml
@@ -1,0 +1,55 @@
+<pendingList>
+    <account>
+        <accountId>68023</accountId>
+        <customFieldList>
+            <customField name="Customer Number">D987DDD</customField>
+            <customField name="Group Code">G81113</customField>
+        </customFieldList>
+        <accountInfo>
+            <firstName>Jane</firstName>
+            <lastName>Doe</lastName>
+            <address address1="2343 Main Street" city="Arlington"
+                     state="VA" postalCode="22201" country="US"/>
+            <email>jane_doe@acme.com</email>
+            <organization>ACME Corp</organization>
+            <jobTitle>Building Adminstrator</jobTitle>
+            <phone>800-555-1515</phone>
+        </accountInfo>
+        <connectionAudit>
+            <createdBy>acme_jane</createdBy>
+            <createdByAccountId>68023</createdByAccountId>
+            <createdDate>2014-12-04T11:29:54.000-05:00</createdDate>
+            <lastUpdatedBy>acme_jane</lastUpdatedBy>
+            <lastUpdatedByAccountId>68023</lastUpdatedByAccountId>
+            <lastUpdatedDate>2014-12-04T16:29:54.000-05:00</lastUpdatedDate>
+        </connectionAudit>
+    </account>
+    <account>
+        <accountId>3243</accountId>
+        <customFieldList>
+            <customField name="Customer Number">X868867D</customField>
+            <customField name="Group Code">G93328788</customField>
+        </customFieldList>
+        <accountInfo>
+            <firstName>Joe</firstName>
+            <lastName>Smith</lastName>
+            <address address1="3432 Times Square Blvd" city="New York City"
+                     postalCode="10453" state="NY" country="US"/>
+            <email>joe_smith@sample.com</email>
+            <organization>Sample Company</organization>
+            <jobTitle>Building Adminstrator</jobTitle>
+            <phone>800-555-1515</phone>
+        </accountInfo>
+        <connectionAudit>
+            <createdBy>acme_smith</createdBy>
+            <createdByAccountId>3243</createdByAccountId>
+            <createdDate>2014-12-03T11:29:54.000-05:00</createdDate>
+            <lastUpdatedBy>acme_smith</lastUpdatedBy>
+            <lastUpdatedByAccountId>3243</lastUpdatedByAccountId>
+            <lastUpdatedDate>2014-12-03T16:29:54.000-05:00</lastUpdatedDate>
+        </connectionAudit>
+    </account>
+    <links>
+        <link linkDescription="next page" link="/connect/account/pending/list?page=2" httpMethod="GET"/>
+    </links>
+</pendingList>

--- a/spec/lib/portfolio_manager/rest/connection_spec.rb
+++ b/spec/lib/portfolio_manager/rest/connection_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe PortfolioManager::REST::Connection do
+  let(:client) { test_client }
+  
+  describe '#pending_list' do
+    before do
+      stub_get('/connect/account/pending/list')
+        .to_return(body: fixture('pending_list.xml'))
+    end
+    it 'returns a list of pending connections' do
+      client.pending_list['pendingList']['account'].each do |account|
+        expect(account).to include 'accountInfo', 'accountId', 'customFieldList', 'customFieldList', 'connectionAudit'
+      end
+    end
+  end
+
+  describe '#connection' do
+    let(:id) { 68001 }
+
+    context 'when accepting a connection' do
+      before do
+        stub_post("/connect/account/#{id}")
+          .with(body: fixture('connection_accept.xml').read, headers: { 'Content-Type'=>'application/xml' })
+          .to_return(body: fixture('connection.xml'))
+      end
+
+      it 'returns status OK' do
+        expect(client.connection(id)['response']['@status']).to eq('Ok')
+      end
+    end
+
+    context 'when rejecting a connection' do
+      before do
+        stub_post("/connect/account/#{id}")
+          .with(body: fixture('connection_reject.xml').read, headers: { 'Content-Type'=>'application/xml' })
+          .to_return(body: fixture('connection.xml'))
+      end
+
+      it 'returns status OK' do
+        expect(client.connection(id, false)['response']['@status']).to eq('Ok')
+      end
+    end
+  end
+end

--- a/spec/lib/portfolio_manager/rest/customer_spec.rb
+++ b/spec/lib/portfolio_manager/rest/customer_spec.rb
@@ -7,10 +7,23 @@ describe PortfolioManager::REST::Customer do
       stub_get("/customer/list")
         .to_return(body: fixture('customer_list.xml'))
     end
+
     it 'returns a list of customers' do
       client.customer_list['response']['links']['link'].each do |link|
         expect(link).to include '@id', '@link'
       end
+    end
+  end
+
+  describe '#customer' do
+    let(:id) { 68001 }
+    before do
+      stub_get("/customer/#{id}")
+        .to_return(body: fixture('customer.xml'))
+    end
+    it 'returns a customer' do
+      expect(client.customer(id)['customer'])
+        .to include 'username', 'accountInfo', 'includeTestPropertiesInGraphics'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,10 @@ def stub_get(path)
   stub_request(:get, /#{stubbed_url + path}/)
 end
 
+def stub_post(path)
+  stub_request(:post, /#{stubbed_url + path}/)
+end
+
 def stubbed_url
   URI(PortfolioManager::REST::Request::BASE_URL).host +
     PortfolioManager::REST::Request::TEST_PATH


### PR DESCRIPTION
This adds PortfolioManager connection services to the gem starting with listing connection requests and accepting/rejecting them. This required adding post requests: https://portfoliomanager.energystar.gov/webservices/home/api/connection

Also fixes type in get customer and adds associated spec.