### PR TITLE
Version 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in portfolio_manager.gemspec
 gemspec
 
 group :test do
-  gem 'webmock'
   gem 'coveralls', require: false
+  gem 'webmock'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "portfolio_manager"
+require 'bundler/setup'
+require 'portfolio_manager'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "portfolio_manager"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/lib/portfolio_manager.rb
+++ b/lib/portfolio_manager.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/client'
 require 'portfolio_manager/version'

--- a/lib/portfolio_manager/rest/account.rb
+++ b/lib/portfolio_manager/rest/account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager

--- a/lib/portfolio_manager/rest/api.rb
+++ b/lib/portfolio_manager/rest/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/account'
 require 'portfolio_manager/rest/building'
 require 'portfolio_manager/rest/data_exchange_settings'

--- a/lib/portfolio_manager/rest/building.rb
+++ b/lib/portfolio_manager/rest/building.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager

--- a/lib/portfolio_manager/rest/client.rb
+++ b/lib/portfolio_manager/rest/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/api'
 require 'portfolio_manager/rest/utils'
 

--- a/lib/portfolio_manager/rest/connection.rb
+++ b/lib/portfolio_manager/rest/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager
@@ -7,9 +9,9 @@ module PortfolioManager
     # @see https://portfoliomanager.energystar.gov/webservices/home/api/connection
     module Connection
       include PortfolioManager::REST::Utils
-      REJECT_NOTE = 'Unfortunately we cannot provide services for you at this time.'.freeze
-      ACCEPT_NOTE = 'Your connection request has been verified and accepted.'.freeze
-      
+      REJECT_NOTE = 'Unfortunately we cannot provide services for you at this time.'
+      ACCEPT_NOTE = 'Your connection request has been verified and accepted.'
+
       ##
       # This web service returns a list of pending customer connection requests.
       # A connection to the customer must be established first before any properties and meters can be shared with you.
@@ -27,9 +29,9 @@ module PortfolioManager
       # @see https://portfoliomanager.energystar.gov/webservices/home/api/connection/connect/post
       def connection_request(customer_id, accept = true)
         perform_post_request(
-            "/connect/account/#{customer_id}",
-            body: connection_response_body(accept)
-          )
+          "/connect/account/#{customer_id}",
+          body: connection_response_body(accept)
+        )
       end
 
       private

--- a/lib/portfolio_manager/rest/customer.rb
+++ b/lib/portfolio_manager/rest/customer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager
@@ -13,7 +15,7 @@ module PortfolioManager
       #
       # @see https://portfoliomanager.energystar.gov/webservices/home/api/account/customerList/get
       def customer_list
-        perform_get_request("/customer/list")
+        perform_get_request('/customer/list')
       end
 
       ##

--- a/lib/portfolio_manager/rest/data_exchange_settings.rb
+++ b/lib/portfolio_manager/rest/data_exchange_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager

--- a/lib/portfolio_manager/rest/meter.rb
+++ b/lib/portfolio_manager/rest/meter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager

--- a/lib/portfolio_manager/rest/property.rb
+++ b/lib/portfolio_manager/rest/property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager

--- a/lib/portfolio_manager/rest/request.rb
+++ b/lib/portfolio_manager/rest/request.rb
@@ -30,7 +30,6 @@ module PortfolioManager
         @conn = Faraday.new(url: BASE_URL) do |conn|
           conn.request :authorization, :basic, client.username, client.password
           conn.request :xml
-          conn.response :xml
         end
         @parser = Nori.new
         setup_client

--- a/lib/portfolio_manager/rest/share.rb
+++ b/lib/portfolio_manager/rest/share.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/utils'
 
 module PortfolioManager
@@ -9,7 +11,7 @@ module PortfolioManager
       include PortfolioManager::REST::Utils
 
       ##
-      # Returns a list of property or meter share requests that are pending. 
+      # Returns a list of property or meter share requests that are pending.
       # These property share requests belong to customers that you are already connected to.
       # The list of pending property share requests is returned in sets of 20.
       #
@@ -37,17 +39,17 @@ module PortfolioManager
       end
 
       private
-      
+
       def pending_shares(resource_name, link)
-        link ||= "/share/#{resource_name}/pending/list" 
+        link ||= "/share/#{resource_name}/pending/list"
         perform_get_request(link)
       end
 
       def share_request(resource_id, resource_name, accept = true)
         perform_post_request(
-            "/share/#{resource_name}/#{resource_id}",
-            body: share_response_body(accept, resource_name)
-          )
+          "/share/#{resource_name}/#{resource_id}",
+          body: share_response_body(accept, resource_name)
+        )
       end
 
       def share_response_body(accept, resource_name)

--- a/lib/portfolio_manager/rest/utils.rb
+++ b/lib/portfolio_manager/rest/utils.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'portfolio_manager/rest/request'
+require 'nokogiri'
 
 module PortfolioManager
   module REST

--- a/lib/portfolio_manager/rest/utils.rb
+++ b/lib/portfolio_manager/rest/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'portfolio_manager/rest/request'
 
 module PortfolioManager
@@ -35,11 +37,11 @@ module PortfolioManager
       end
 
       def request_response_xml(action, note)
-        builder = Nokogiri::XML::Builder.new do |xml|
-          xml.sharingResponse {
+        Nokogiri::XML::Builder.new do |xml|
+          xml.sharingResponse do
             xml.action action
             xml.note note
-          }
+          end
         end.to_xml
       end
     end

--- a/lib/portfolio_manager/version.rb
+++ b/lib/portfolio_manager/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PortfolioManager
   VERSION = '0.1.0'
 end

--- a/lib/portfolio_manager/version.rb
+++ b/lib/portfolio_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PortfolioManager
-  VERSION = '0.1.0'
+  VERSION = '0.4.0'
 end

--- a/portfolio_manager.gemspec
+++ b/portfolio_manager.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'portfolio_manager/version'
 
@@ -9,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Jack Reed']
   spec.email         = ['phillipjreed@gmail.com']
 
-  spec.summary       = %q{A Ruby client for the EnergyStar Portfolio Manager web services.}
-  spec.description   = %q{A Ruby client for the EnergyStar Portfolio Manager web services.}
+  spec.summary       = 'A Ruby client for the EnergyStar Portfolio Manager web services.'
+  spec.description   = 'A Ruby client for the EnergyStar Portfolio Manager web services.'
   spec.homepage      = 'https://github.com/mejackreed/portfolio_manager'
   spec.license       = 'MIT'
 
@@ -19,11 +20,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'hurley'
+  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday-xml'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'nori'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 end

--- a/spec/lib/portfolio_manager/rest/account_spec.rb
+++ b/spec/lib/portfolio_manager/rest/account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Account do

--- a/spec/lib/portfolio_manager/rest/building_spec.rb
+++ b/spec/lib/portfolio_manager/rest/building_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Building do

--- a/spec/lib/portfolio_manager/rest/client_spec.rb
+++ b/spec/lib/portfolio_manager/rest/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Client do

--- a/spec/lib/portfolio_manager/rest/connection_spec.rb
+++ b/spec/lib/portfolio_manager/rest/connection_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Connection do
   let(:client) { test_client }
-  
+
   describe '#pending_connection_requests' do
     before do
       stub_get('/connect/account/pending/list')
@@ -17,12 +19,19 @@ describe PortfolioManager::REST::Connection do
   end
 
   describe '#property_share' do
-    let(:id) { 68001 }
+    let(:id) { 68_001 }
 
     context 'when accepting a property share' do
       before do
         stub_post("/connect/account/#{id}")
-          .with(body: fixture('connection_accept.xml').read, headers: { 'Content-Type'=>'application/xml' })
+          .with(body: fixture('connection_accept.xml').read,
+                headers: {
+                  'Accept' => 'application/xml',
+                  'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                  'Authorization' => 'Basic dXNlcjpwYXNz',
+                  'Content-Type' => 'application/xml;charset=UTF-8',
+                  'User-Agent' => 'Ruby PortfolioManager API Client'
+                })
           .to_return(body: fixture('response_status_ok.xml'))
       end
 
@@ -34,7 +43,14 @@ describe PortfolioManager::REST::Connection do
     context 'when rejecting a connection' do
       before do
         stub_post("/connect/account/#{id}")
-          .with(body: fixture('connection_reject.xml').read, headers: { 'Content-Type'=>'application/xml' })
+          .with(body: fixture('connection_reject.xml').read,
+                headers: {
+                  'Accept' => 'application/xml',
+                  'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                  'Authorization' => 'Basic dXNlcjpwYXNz',
+                  'Content-Type' => 'application/xml;charset=UTF-8',
+                  'User-Agent' => 'Ruby PortfolioManager API Client'
+                })
           .to_return(body: fixture('response_status_ok.xml'))
       end
 

--- a/spec/lib/portfolio_manager/rest/customer_spec.rb
+++ b/spec/lib/portfolio_manager/rest/customer_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Customer do
   let(:client) { test_client }
   describe '#customer_list' do
     before do
-      stub_get("/customer/list")
+      stub_get('/customer/list')
         .to_return(body: fixture('customer_list.xml'))
     end
 
@@ -16,7 +18,7 @@ describe PortfolioManager::REST::Customer do
   end
 
   describe '#customer' do
-    let(:id) { 68001 }
+    let(:id) { 68_001 }
     before do
       stub_get("/customer/#{id}")
         .to_return(body: fixture('customer.xml'))

--- a/spec/lib/portfolio_manager/rest/data_exchange_settings_spec.rb
+++ b/spec/lib/portfolio_manager/rest/data_exchange_settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::DataExchangeSettings do

--- a/spec/lib/portfolio_manager/rest/meter_spec.rb
+++ b/spec/lib/portfolio_manager/rest/meter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Meter do

--- a/spec/lib/portfolio_manager/rest/property_spec.rb
+++ b/spec/lib/portfolio_manager/rest/property_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Property do

--- a/spec/lib/portfolio_manager/rest/share_spec.rb
+++ b/spec/lib/portfolio_manager/rest/share_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager::REST::Share do
   let(:client) { test_client }
-  
+
   describe '#pending_share' do
     context 'property' do
       before do
@@ -12,7 +14,8 @@ describe PortfolioManager::REST::Share do
 
       it 'returns a list of pending property shares' do
         client.pending_property_shares['pendingList']['property'].each do |property|
-          expect(property).to include 'propertyId', 'customFieldList', 'accessLevel', 'accountId', 'propertyInfo', 'shareAudit'
+          expect(property).to include 'propertyId', 'customFieldList', 'accessLevel', 'accountId', 'propertyInfo',
+                                      'shareAudit'
         end
       end
     end
@@ -25,20 +28,30 @@ describe PortfolioManager::REST::Share do
 
       it 'returns a list of pending meter shares' do
         client.pending_meter_shares['pendingList']['meter'].each do |meter|
-          expect(meter).to include 'meterId', 'meterInfo', 'propertyId', 'customFieldList', 'accessLevel', 'accountId', 'propertyInfo', 'shareAudit'
+          expect(meter).to include 'meterId', 'meterInfo', 'propertyId', 'customFieldList', 'accessLevel', 'accountId',
+                                   'propertyInfo', 'shareAudit'
         end
       end
     end
   end
 
   describe '#share' do
-    let(:id) { 68001 }
+    let(:id) { 68_001 }
 
     context 'property' do
       context 'when accepting share' do
         before do
           stub_post("/share/property/#{id}")
-            .with(body: fixture('property_share_accept.xml').read, headers: { 'Content-Type'=>'application/xml' })
+            .with(
+              body: fixture('property_share_accept.xml').read,
+              headers: {
+                'Accept' => 'application/xml',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'Authorization' => 'Basic dXNlcjpwYXNz',
+                'Content-Type' => 'application/xml;charset=UTF-8',
+                'User-Agent' => 'Ruby PortfolioManager API Client'
+              }
+            )
             .to_return(body: fixture('response_status_ok.xml'))
         end
 
@@ -50,7 +63,16 @@ describe PortfolioManager::REST::Share do
       context 'when rejecting share' do
         before do
           stub_post("/share/property/#{id}")
-            .with(body: fixture('property_share_reject.xml').read, headers: { 'Content-Type'=>'application/xml' })
+            .with(
+              body: fixture('property_share_reject.xml').read,
+              headers: {
+                'Accept' => 'application/xml',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'Authorization' => 'Basic dXNlcjpwYXNz',
+                'Content-Type' => 'application/xml;charset=UTF-8',
+                'User-Agent' => 'Ruby PortfolioManager API Client'
+              }
+            )
             .to_return(body: fixture('response_status_ok.xml'))
         end
 
@@ -64,7 +86,14 @@ describe PortfolioManager::REST::Share do
       context 'when accepting share' do
         before do
           stub_post("/share/meter/#{id}")
-            .with(body: fixture('meter_share_accept.xml').read, headers: { 'Content-Type'=>'application/xml' })
+            .with(body: fixture('meter_share_accept.xml').read,
+                  headers: {
+                    'Accept' => 'application/xml',
+                    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                    'Authorization' => 'Basic dXNlcjpwYXNz',
+                    'Content-Type' => 'application/xml;charset=UTF-8',
+                    'User-Agent' => 'Ruby PortfolioManager API Client'
+                  })
             .to_return(body: fixture('response_status_ok.xml'))
         end
 
@@ -76,7 +105,14 @@ describe PortfolioManager::REST::Share do
       context 'when rejecting share' do
         before do
           stub_post("/share/meter/#{id}")
-            .with(body: fixture('meter_share_reject.xml').read, headers: { 'Content-Type'=>'application/xml' })
+            .with(body: fixture('meter_share_reject.xml').read,
+                  headers: {
+                    'Accept' => 'application/xml',
+                    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                    'Authorization' => 'Basic dXNlcjpwYXNz',
+                    'Content-Type' => 'application/xml;charset=UTF-8',
+                    'User-Agent' => 'Ruby PortfolioManager API Client'
+                  })
             .to_return(body: fixture('response_status_ok.xml'))
         end
 

--- a/spec/portfolio_manager_spec.rb
+++ b/spec/portfolio_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe PortfolioManager do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'portfolio_manager'
 require 'webmock/rspec'
 require 'coveralls'
@@ -6,11 +8,11 @@ require 'coveralls'
 Coveralls.wear!
 
 def fixture(file)
-  File.new(fixture_path + '/' + file)
+  File.new("#{fixture_path}/#{file}")
 end
 
 def fixture_path
-  File.expand_path('../fixtures', __FILE__)
+  File.expand_path('fixtures', __dir__)
 end
 
 def test_client


### PR DESCRIPTION
@mejackreed this modernizes the client from the long-deprecated hurley to faraday so that this gem can be compatible with Ruby 3

I went ahead and ran rubocop to bring the syntax up to standards globally. Specs pass and there should be no breaking changes for users. e.g., I kept the nori xml to hash parser instead of using the faraday-xml parser on the response to prevent adding a breaking change.

No additional functionality has been added. Just an upgrade under the hood.